### PR TITLE
indexとfooterの文言修正

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -4,7 +4,7 @@
       <header></header>
       <nuxt />
       <footer class="mt-16 md:mt-32 text-center text-xs">
-        COPYRIGHTS ALLRIGHTS RESERVED© seijishukyoproyakyu.
+        &copy; 2021 seijishukyoproyakyu.
       </footer>
     </div>
   </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -66,7 +66,7 @@
       </div>
     </div>
     <div class="section">
-      <span class="title">Movies</span>
+      <span class="title">Videos</span>
       <div class="movie_outer w-full">
         <client-only>
           <movie


### PR DESCRIPTION
## Problem

* indexページ 動画一覧のタイトルを"Movies"から"Videos"に文言修正する。
* コピーライトの文言を整理する。

## Solution

* 文言修正を行った。

## Testing

<img width="443" alt="Screen Shot 2021-03-14 at 18 17 53" src="https://user-images.githubusercontent.com/51022322/111063437-cf9ba180-84f1-11eb-9582-98c35553b1f7.png">
<img width="340" alt="Screen Shot 2021-03-14 at 18 18 11" src="https://user-images.githubusercontent.com/51022322/111063441-d32f2880-84f1-11eb-8177-9e60f97cb1ef.png">
